### PR TITLE
Improve error message in `check_rs2_error` for unknown exception type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -137,18 +137,18 @@ macro_rules! check_rs2_error {
     ($rs2_error:expr, $result:expr) => {
         // We make this alias here to type check $rs2_error.
         {
-            use crate::kind::Rs2Exception;
             use num_traits::FromPrimitive;
             use std::convert::TryInto;
+            use $crate::kind::Rs2Exception;
             let err: *mut sys::rs2_error = $rs2_error;
             if err.as_ref().is_some() {
+                let realsense_exception_type = sys::rs2_get_librealsense_exception_type(err);
+                let realsense_exception_type_i32 = realsense_exception_type.try_into().unwrap();
+
                 let res = $result(
-                    Rs2Exception::from_i32(
-                        sys::rs2_get_librealsense_exception_type(err)
-                            .try_into()
-                            .unwrap(),
-                    )
-                    .unwrap(),
+                    Rs2Exception::from_i32(realsense_exception_type_i32).unwrap_or_else(|| {
+                        panic!("Unknown Rs2Exception: {}", realsense_exception_type_i32)
+                    }),
                     std::ffi::CStr::from_ptr(sys::rs2_get_error_message(err))
                         .to_str()
                         .unwrap()


### PR DESCRIPTION
I am trying to get realsense working on an M1 MacBook. I installed librealsense 2.54.1 with `brew install librealsense`. I then tried to run [`demo_435i`](https://github.com/Tangram-Vision/realsense-rust/blob/main/examples/demo_435i.rs) and got this:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', realsense-rust-1.1.0/src/device.rs:82:13
stack backtrace:
   0: rust_begin_unwind
             at std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   2: core::panicking::panic
             at core/src/panicking.rs:111:5
   3: core::option::Option<T>::unwrap
             at core/src/option.rs:778:21
   4: realsense_rust::device::Device::try_create
             at realsense-rust-1.1.0/src/device.rs:82:13
   5: realsense_rust::context::Context::query_devices
             at realsense-rust-1.1.0/src/context.rs:118:23
```

With this PR applied this is improved to:

```
thread 'main' panicked at 'Unknown Rs2Exception: 8', realsense-rust/src/device.rs:82:13
stack backtrace:
   0: rust_begin_unwind
             at std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at core/src/panicking.rs:64:14
   2: realsense_rust::device::Device::try_create::{{closure}}
             at realsense-rust/src/error.rs:150:25
   3: core::option::Option<T>::unwrap_or_else
             at core/src/option.rs:828:21
   4: realsense_rust::device::Device::try_create
             at realsense-rust/src/device.rs:82:13
   5: realsense_rust::context::Context::query_devices
             at realsense-rust/src/context.rs:118:23
```

I still don't know why we get an `8` here though, considering there are only eight errors, numbered 0-7: https://intelrealsense.github.io/librealsense/doxygen/rs__types_8h.html#ab73d6772c40d1a2fba645a1d0a7eed5e

Perhaps some version mismatch?

---

PS: in your [`README.md`](https://github.com/Tangram-Vision/realsense-rust#realsense-bindings-for-rust) and on https://crates.io/crates/realsense-rust you say you are happy to receive PRs on GitHub (which is why  opened this PR), but now I see that [`CONTRIBUTING.md`](https://github.com/Tangram-Vision/realsense-rust/blob/main/CONTRIBUTING.md) says you only accept them on GitLab 😬